### PR TITLE
Updated Ringer download button

### DIFF
--- a/src/ringer.html
+++ b/src/ringer.html
@@ -48,7 +48,7 @@
 <header>.
     <div class="header-title">
         <img src="assets/Images/Services/Ringerlogo.png" /> 
-        <button type="button" onclick="window.location.href='ringer waitlist.html';">Join The Waitlist</button>
+        <button type="button" onclick="window.location.href='ringer downloads.html';">Download Ringer</button>
     </div>
     <div class="header-divider">
         <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">


### PR DESCRIPTION
### Description
Removed the "Join the Waitlist" button on the Ringer page and replaced it with the "Download Ringer" button which redirects to the Ringer downloads page.